### PR TITLE
fix bug in feature extraction?

### DIFF
--- a/detectormorse/detector.py
+++ b/detectormorse/detector.py
@@ -155,7 +155,7 @@ class Detector(JSONable):
             if "." in L:
                 yield "L:*period*"
             if not self.nocase:
-                cf = case_feature(R)
+                cf = case_feature(L)
                 if cf:
                     yield "L:{}'".format(cf)
             L = L.upper()


### PR DESCRIPTION
To me, it looks like there might be a bug in the feature extraction code for the left token case feature. The `L:*case*` feature seems to use the right token instead of the left one, and the "real" `R:*case*` feature isn't used.

```python
>>> import detectormorse
>>> det = detectormorse.Detector()
>>> det.extract_one('Dr', '.', 'PEPPER')
['*bias*', 'len(L)=2', "L:*uppercase*'", 'L:*no-vowel*', "L='DR'", "P='.'", "R:*uppercase*'", "R='PEPPER'", "L='DR',R='PEPPER'"]
```

Here, the `L:*uppercase*` feature should be `L:*titlecase*`, shouldn't it? This PR changes the code to do this, but I think that this change might actually make the default model perform a little worse (since it was trained with the "wrong" `L:*case*` feature), so this probably shouldn't be merged before retraining a model and seeing if it actually does better.